### PR TITLE
Refactor fragment init logic and separation

### DIFF
--- a/LearningApp/app/src/main/java/com/example/justina/learningapp/ui/activity/ViewChartsActivity.java
+++ b/LearningApp/app/src/main/java/com/example/justina/learningapp/ui/activity/ViewChartsActivity.java
@@ -1,90 +1,33 @@
 package com.example.justina.learningapp.ui.activity;
 
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
-import android.content.res.Resources;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
-import android.view.View;
-import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
-import android.widget.GridView;
-import android.widget.ListView;
-import android.widget.TextView;
+import android.support.v7.app.AppCompatActivity;
 
-import com.example.justina.learningapp.data.adapter.ImageAdapter;
 import com.example.justina.learningapp.R;
+import com.example.justina.learningapp.ui.fragment.MonthListFragment;
 import com.example.justina.learningapp.ui.fragment.TopChartFragment;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class ViewChartsActivity extends AppCompatActivity {
-
-    public Map<Integer, String> months;{
-        months = new HashMap<>();
-        months.put( 1,"January");
-        months.put( 2,"February");
-        months.put( 3,"March");
-        months.put( 4,"April");
-        months.put( 5,"May");
-        months.put( 6,"June");
-        months.put( 7,"July");
-        months.put( 8,"August");
-        months.put( 9,"September");
-        months.put(10,"October");
-        months.put(11,"November");
-        months.put(12,"December");
-    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_view_charts);
 
-        // Content for the first fragment
-        GridView gridview = (GridView) findViewById(R.id.gridView);
-        gridview.setAdapter(new ImageAdapter(this));
+        // top charts fragment
+        TopChartFragment topChartFragment = TopChartFragment.newInstance();
+        getSupportFragmentManager()
+                .beginTransaction()
+                .add(R.id.view_charts_top_chart_holder, topChartFragment, TopChartFragment.FRAGMENT_TAG)
+                .commitAllowingStateLoss();
 
-        // Second fragment
-        TopChartFragment chartFragment = new TopChartFragment();
-        FragmentManager fManager = getFragmentManager();
-        FragmentTransaction fTransaction = fManager.beginTransaction();
-        fTransaction.add(R.id.chart_activity_layout,chartFragment,"chartFragment");
-        fTransaction.commit();
-
-        gridview.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-
-            public void onItemClick(AdapterView<?> parent, View v, int position, long id) {
-                int monthNo = position + 1;
-                populateTopList(monthNo);
-            }
-        });
-    }
-
-    public void populateTopList(int monthNo) {
-        TextView textValue = (TextView) findViewById(R.id.month_chart);
-        textValue.setText("TranceFix TOP10 of " + months.get(monthNo));
-
-        Resources topTen = getResources();
-        String[] tracks;
-
-        if (monthNo == 1){
-            tracks = topTen.getStringArray(R.array.top10_jan);
-        }
-        else if (monthNo == 2) {
-            tracks = topTen.getStringArray(R.array.top10_feb);
-        }
-        else if (monthNo == 3) {
-            tracks = topTen.getStringArray(R.array.top10_mar);
-        }
-        else {
-            tracks = topTen.getStringArray(R.array.top10_apr);
-        }
-
-        ArrayAdapter<String> adapter = new ArrayAdapter<String>(this, R.layout.top10_list, tracks);
-        ListView trackList = (ListView) findViewById(R.id.topTenList);
-        trackList.setAdapter(adapter);
+        // month list fragment
+        MonthListFragment monthListFragment = new MonthListFragment();
+        monthListFragment.setOnMonthSelectedListener(topChartFragment);
+        getSupportFragmentManager()
+                .beginTransaction()
+                .add(R.id.view_charts_month_list_holder, monthListFragment, MonthListFragment.FRAGMENT_TAG)
+                .commitAllowingStateLoss();
     }
 
 }

--- a/LearningApp/app/src/main/java/com/example/justina/learningapp/ui/fragment/MonthListFragment.java
+++ b/LearningApp/app/src/main/java/com/example/justina/learningapp/ui/fragment/MonthListFragment.java
@@ -1,19 +1,87 @@
 package com.example.justina.learningapp.ui.fragment;
 
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.GridView;
 
 import com.example.justina.learningapp.R;
+import com.example.justina.learningapp.data.adapter.ImageAdapter;
 
+import java.util.ArrayList;
+import java.util.List;
 
 public class MonthListFragment extends Fragment {
+
+    public static String FRAGMENT_TAG = MonthListFragment.class.getName();
+
+    private final List<String> months;
+
+    private GridView viewMonthList;
+
+    private OnMonthSelectedListener onMonthSelectedListener;
+
+    public MonthListFragment() {
+        months = new ArrayList<>();
+
+        months.add("January");
+        months.add("February");
+        months.add("March");
+        months.add("April");
+        months.add("May");
+        months.add("June");
+        months.add("July");
+        months.add("August");
+        months.add("September");
+        months.add("October");
+        months.add("November");
+        months.add("December");
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_monthlist, container, false);
     }
 
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        viewMonthList = (GridView) view.findViewById(R.id.month_list);
+        viewMonthList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                if (onMonthSelectedListener != null) {
+                    onMonthSelectedListener.onMonthSelected(position, months.get(position));
+                }
+            }
+        });
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        ImageAdapter adapter = new ImageAdapter(getActivity());
+        viewMonthList.setAdapter(adapter);
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+
+        viewMonthList = null;
+    }
+
+    public void setOnMonthSelectedListener(OnMonthSelectedListener onMonthSelectedListener) {
+        this.onMonthSelectedListener = onMonthSelectedListener;
+    }
+
+    public interface OnMonthSelectedListener {
+        void onMonthSelected(int id, String value);
+    }
 }

--- a/LearningApp/app/src/main/java/com/example/justina/learningapp/ui/fragment/TopChartFragment.java
+++ b/LearningApp/app/src/main/java/com/example/justina/learningapp/ui/fragment/TopChartFragment.java
@@ -1,18 +1,92 @@
 package com.example.justina.learningapp.ui.fragment;
 
+import android.content.res.Resources;
 import android.os.Bundle;
-import android.app.Fragment;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
 
 import com.example.justina.learningapp.R;
 
 
-public class TopChartFragment extends Fragment {
+public class TopChartFragment extends Fragment implements MonthListFragment.OnMonthSelectedListener {
+
+    public static String FRAGMENT_TAG = TopChartFragment.class.getName();
+
+    private TextView viewTopChartTitle;
+    private ListView viewTopChartList;
+
+    private ArrayAdapter<String> adapter;
+
+    public TopChartFragment() {
+    }
+
+    public static TopChartFragment newInstance() {
+        final TopChartFragment fragment = new TopChartFragment();
+
+        final Bundle arguments = new Bundle();
+
+        fragment.setArguments(arguments);
+
+        return fragment;
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_top_chart, container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        viewTopChartTitle = (TextView) view.findViewById(R.id.top_chart_title);
+        viewTopChartList = (ListView) view.findViewById(R.id.top_chart_list);
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        adapter = new ArrayAdapter<>(getActivity(), R.layout.top10_list);
+        viewTopChartList.setAdapter(adapter);
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+
+        viewTopChartTitle = null;
+        viewTopChartList = null;
+    }
+
+    @Override
+    public void onMonthSelected(int id, String value) {
+        viewTopChartTitle.setText("TranceFix TOP10 of " + value);
+
+        Resources resources = getResources();
+        String[] tracks;
+
+        switch (id) {
+            case 1:
+                tracks = resources.getStringArray(R.array.top10_jan);
+                break;
+            case 2:
+                tracks = resources.getStringArray(R.array.top10_feb);
+                break;
+            case 3:
+                tracks = resources.getStringArray(R.array.top10_mar);
+                break;
+            default:
+                tracks = resources.getStringArray(R.array.top10_apr);
+        }
+
+        adapter.clear();
+        adapter.addAll(tracks);
     }
 }

--- a/LearningApp/app/src/main/res/layout/activity_view_charts.xml
+++ b/LearningApp/app/src/main/res/layout/activity_view_charts.xml
@@ -1,35 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:id="@+id/chart_activity_layout"
-    tools:context=".ui.activity.ViewChartsActivity">
+<LinearLayout android:id="@+id/chart_activity_layout"
+              xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical"
+              android:padding="@dimen/activity_vertical_margin"
+              tools:context=".ui.activity.ViewChartsActivity">
 
     <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:text="Monthly Charts"
         android:id="@+id/chartActivityHeader"
-        android:textColor="@color/textBrickRed"
-        android:layout_alignParentTop="true"
-        android:layout_centerHorizontal="true" />
-
-    <fragment
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:name="com.example.justina.learningapp.ui.fragment.MonthListFragment"
-        android:id="@+id/month_fragment"
-        android:layout_below="@+id/chartActivityHeader"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentEnd="true"
-        android:layout_marginTop="20dp" />
+        android:layout_gravity="center_horizontal"
+        android:text="Monthly Charts"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textColor="@color/textBrickRed"/>
 
-</RelativeLayout>
+    <FrameLayout
+        android:id="@+id/view_charts_month_list_holder"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"/>
+
+    <FrameLayout
+        android:id="@+id/view_charts_top_chart_holder"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+</LinearLayout>

--- a/LearningApp/app/src/main/res/layout/fragment_monthlist.xml
+++ b/LearningApp/app/src/main/res/layout/fragment_monthlist.xml
@@ -7,7 +7,7 @@
     <GridView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/gridView"
+        android:id="@+id/month_list"
         android:layout_marginTop="10dp"
         android:layout_marginBottom="10dp"
         android:numColumns="4"

--- a/LearningApp/app/src/main/res/layout/fragment_top_chart.xml
+++ b/LearningApp/app/src/main/res/layout/fragment_top_chart.xml
@@ -1,25 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="fill_parent"
-    android:layout_below="@+id/month_fragment">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="wrap_content"
+              android:layout_height="match_parent"
+              android:orientation="vertical">
 
     <TextView
-        android:id="@+id/month_chart"
+        android:id="@+id/top_chart_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        android:gravity="center_horizontal"
         android:text="@string/top10_header"
-        android:textAlignment="center"
-        android:textColor="@color/textBlue"
-        android:layout_margin="10dp" />
+        android:textColor="@color/textBlue"/>
 
     <ListView
+        android:id="@+id/top_chart_list"
         android:layout_width="match_parent"
-        android:layout_height="fill_parent"
-        android:id="@+id/topTenList"
-        android:layout_below="@+id/month_chart"
-        android:layout_alignLeft="@+id/month_chart"
-        android:layout_alignStart="@+id/month_chart"
-        android:layout_marginTop="10dp" />
+        android:layout_height="0dp"
+        android:layout_marginTop="10dp"
+        android:layout_weight="1"/>
 
-</RelativeLayout>
+</LinearLayout>


### PR DESCRIPTION
Fragment have different lifecycle should be used as independent entities and not as activity views.

Do not refer view id's from different layout (`fragment_top_chart.xml` -> `android:layout_below="@+id/month_fragment"`)

Android system when recreating fragment (on rotation change or low memory and etc.) calls empty constructor and populates set arguments. To avoid data (argument) loss you should either:
1. create static factory method and set arguments after instance is created (updated `TopChartFragment.class`)
2. add set arguments inside non default constructor call

Also you are overusing RelativeLayout where simpler ViewGoup elements (LinearLayout, FrameLayout) can be used. More on why RelativeLayout should be used carefully parent view elements: http://stackoverflow.com/a/17496262/3052012
